### PR TITLE
Bump tmate to 2.3.0, libssh to 0.9.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,17 +1,16 @@
----
 tmate/libevent-2.0.22-stable.tar.gz:
+  size: 854987
   object_id: 8966470b-6ada-4913-ae72-e40c267fdd07
   sha: a586882bc93a208318c70fc7077ed8fca9862864
-  size: 854987
-tmate/libssh-0.7.2.tar.gz:
-  object_id: 73aa2799-a31b-4047-b813-d094e27dfc5e
-  sha: 83320b5c49a2fb32cc6ee32a307ece370863262f
-  size: 479905
+tmate/libssh-0.9.0.tar.gz:
+  size: 700309
+  object_id: c4702c3e-3afc-4841-4cef-97022950da5c
+  sha: sha256:907ee79448c6a40c63535dc65ca68550da1a99f0cf9e040142ac50c0287aa135
 tmate/msgpack-1.4.2.tar.gz:
+  size: 776384
   object_id: aa856e3c-e599-40ce-99fb-f9dccb95c1a8
   sha: 6d284861c47565a5ea4ed135b803225e67cf95e6
-  size: 776384
-tmate/tmate-slave-master.tar.gz:
-  object_id: 593e0405-2b77-4916-87e2-c0825ce02011
-  sha: 7b59bf771c7619d7fe530367546cfcb64627cf17
-  size: 863800
+tmate/tmate-ssh-server-2.3.0.tar.gz:
+  size: 902736
+  object_id: 6b0af76b-b7a2-462c-471d-5312608a9f28
+  sha: sha256:943eb6844aeafc44de782f24f2c6b2a88155894e4f1d9aac54cf97b77aa620d9

--- a/jobs/tmate/templates/bin/ctl
+++ b/jobs/tmate/templates/bin/ctl
@@ -36,7 +36,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     mkdir -p ${STORE_DIR}/keys
-    exec tmate-slave <% if p('tmate.debug') %>-vvvvvv<% end %> \
+    exec tmate-ssh-server <% if p('tmate.debug') %>-vvvvvv<% end %> \
          -k ${STORE_DIR}/keys \
          -h <%= p('tmate.host') %> \
          -p <%= p('tmate.port') %> \

--- a/packages/tmate/packaging
+++ b/packages/tmate/packaging
@@ -8,6 +8,9 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
+TMATE_VERSION=2.3.0
+LIBSSH_VERSION=0.9.0
+
 package="tmate"
 LD_LIBRARY_PATH="/var/vcap/packages/${package}/lib"
 PKG_CONFIG_PATH="/var/vcap/packages/${package}/lib/pkgconfig"
@@ -39,5 +42,5 @@ cmakeit() {
 }
 package "libevent-2.0.22-stable.tar.gz"
 package "msgpack-1.4.2.tar.gz"
-cmakeit "libssh-0.7.2.tar.gz"
-package "tmate-slave-master.tar.gz"
+cmakeit "libssh-$LIBSSH_VERSION.tar.gz"
+package "tmate-ssh-server-$TMATE_VERSION.tar.gz"

--- a/packages/tmate/repack
+++ b/packages/tmate/repack
@@ -3,12 +3,19 @@
 # this script should be run on a workstation in order to repack
 # the tmate source tarball without the autotools dependency
 
+TMATE_VERSION=2.3.0
+
 set -ex
-pushd blobs/tmate
-  curl -L https://github.com/tmate-io/tmate-slave/archive/master.tar.gz | tar -xzv
-  pushd tmate-slave-master
-    ./autogen.sh
-    popd
-  tar -czvf tmate-slave-master.tar.gz tmate-slave-master/
-  rm -rf tmate-slave-master/
+curl -L https://github.com/tmate-io/tmate-ssh-server/archive/$TMATE_VERSION.tar.gz | tar -xzv
+pushd tmate-ssh-server-$TMATE_VERSION
+  ./autogen.sh
   popd
+tar -czvf tmate-ssh-server-$TMATE_VERSION.tar.gz tmate-ssh-server-$TMATE_VERSION
+rm -rf tmate-ssh-server-$TMATE_VERSION
+bosh add-blob tmate-ssh-server-$TMATE_VERSION.tar.gz tmate/tmate-ssh-server-$TMATE_VERSION.tar.gz
+rm tmate-ssh-server-$TMATE_VERSION.tar.gz
+
+# grab libssh, and repackage it from xz to gz for easier compilation
+curl -L https://www.libssh.org/files/0.9/libssh-0.9.0.tar.xz | xz -d | gzip > libssh-0.9.0.tar.gz
+bosh add-blob libssh-0.9.0.tar.gz tmate/libssh-0.9.0.tar.gz
+rm libssh-0.9.0.tar.gz

--- a/packages/tmate/spec
+++ b/packages/tmate/spec
@@ -5,8 +5,8 @@
 name: tmate
 dependencies: []
 files:
-    # retrieved 14 Jul 2016, @090c2b0 (https://github.com/tmate-io/tmate-slave)
-  - tmate/tmate-slave-master.tar.gz
+    # retrieved 14 Jul 2016, @090c2b0 (https://github.com/tmate-io/tmate-ssh-server)
+  - tmate/tmate-ssh-server-*.tar.gz
   - tmate/libevent-2.0.22-stable.tar.gz
   - tmate/msgpack-1.4.2.tar.gz
-  - tmate/libssh-0.7.2.tar.gz
+  - tmate/libssh-*.tar.gz


### PR DESCRIPTION
Fixes #1 

blobs are uploaded. The main downside to this is it requires clients be on tmate 2.3.0 as there was apparently no forward/backward compatibility between 2.2.1 and 2.3.0.